### PR TITLE
Use HTTPResponse.read instead of non-existant readall method

### DIFF
--- a/dblist.py
+++ b/dblist.py
@@ -11,7 +11,7 @@ DB_URL = "%s/%s.db" % (REPO_URL, REPO_NAME)
 
 db_response = urllib.request.urlopen(DB_URL)
 
-db_response = io.BytesIO(db_response.readall())
+db_response = io.BytesIO(db_response.read())
 
 packages = []
 


### PR DESCRIPTION
fixed "AttributeError: 'HTTPResponse' object has no attribute 'readall'" exceptions after upgrading Python from 3.4.3 to 3.5.0 on ArchLinux

https://docs.python.org/3/library/http.client.html#http.client.HTTPResponse.read
https://docs.python.org/2/library/httplib.html#httplib.HTTPResponse.read
